### PR TITLE
Stop function

### DIFF
--- a/node.php
+++ b/node.php
@@ -86,7 +86,7 @@ function node_stop() {
 	}
 	echo "Stopping Node.js with PID=$node_pid:\n";
 	$ret = -1;
-	passthru("kill $node_pid", $ret);
+	passthru("kill -9 $node_pid", $ret);
 	echo $ret === 0 ? "Done.\n" : "Failed. Error: $ret\n";
 	file_put_contents("nodepid", '', LOCK_EX);
 }


### PR DESCRIPTION
I was trying the script on a hostgator shared server and was unable to stop the process. Happens that the `kill` command sends the `TERM` signal by default and, somehow, it wasn't working on my server. Had to update that line to `kill -9` (so it actually sends `SIGKILL`).
It's working fine, now. Great work, by the way!
