### PR TITLE
Added a restart for hosting that kills user processes

### DIFF
--- a/node.php
+++ b/node.php
@@ -117,17 +117,20 @@ function node_serve($path = "") {
 	}
 	$node_pid = intval(file_get_contents("nodepid"));
 	if($node_pid === 0) {
+		node_head();
+		echo "Node.js is not yet running. Switch to Admin Mode and <a href='?start'>Start it</a>\n";
+		node_foot();
+		return;
+	}elseif($RESTART_PROCESS && $node_pid && !posix_getpgid($node_pid)){
 		$nodestart = file_get_contents('nodestart');
-		if(($RESTART_PROCESS === true) && !is_null($nodestart)){
+		if($nodestart){
 			node_start($nodestart);
 			//wait for node process to start, then retry to node_serve
 			sleep(5);
 			node_serve($path);
 			return;
 		}
-		node_head();
-		echo "Node.js is not yet running. Switch to Admin Mode and <a href='?start'>Start it</a>\n";
-		node_foot();
+		echo "Please switch to Admin Mode and manually restart the server. <a href='?start'>Start it</a>\n";
 		return;
 	}
 	$curl = curl_init("http://127.0.0.1:" . NODE_PORT . "/$path");

--- a/node.php
+++ b/node.php
@@ -75,6 +75,9 @@ function node_start($file) {
 	$node_pid = exec("PORT=" . NODE_PORT . " " . NODE_DIR . "/bin/node $file >nodeout 2>&1 & echo $!");
 	echo $node_pid > 0 ? "Done. PID=$node_pid\n" : "Failed.\n";
 	file_put_contents("nodepid", $node_pid, LOCK_EX);
+	if($node_pid>0){
+		file_put_contents('nodestart', $file, LOCK_EX);
+	}
 	sleep(1); //Wait for node to spin up
 	echo file_get_contents("nodeout");
 }
@@ -178,7 +181,6 @@ function node_dispatch() {
 		} elseif(isset($_GET['uninstall'])) {
 			node_uninstall();
 		} elseif(isset($_GET['start'])) {
-			file_put_contents('nodestart', $_GET['start']);
 			node_start($_GET['start']);
 		} elseif(isset($_GET['stop'])) {
 			node_stop();


### PR DESCRIPTION
Some shared hosting, such as Namecheap, will periodically kill off users' processes. This should allow the process to be restarted when a request comes in while the process is dead.
