### PR TITLE
fix: prevent argument injection / RCE in npm command handler

### DIFF
--- a/node.php
+++ b/node.php
@@ -101,7 +101,14 @@ function node_npm($cmd) {
 		echo "Node.js is not yet installed. <a href='?install'>Install it</a>.\n";
 		return;
 	}
-	$cmd = escapeshellcmd(NODE_DIR . "/bin/npm --cache ./.npm -- $cmd");
+	// Whitelist allowed npm subcommands to prevent arbitrary command execution
+	$allowed = array('install', 'uninstall', 'update', 'list', 'ls', 'outdated', 'init', 'version');
+	$parts = explode(' ', trim($cmd), 2);
+	if (!in_array($parts[0], $allowed)) {
+		echo "Error: npm subcommand not allowed.\n";
+		return;
+	}
+	$cmd = NODE_DIR . "/bin/npm --cache ./.npm -- " . escapeshellarg($cmd);
 	echo "Running: $cmd\n";
 	$ret = -1;
 	passthru($cmd, $ret);


### PR DESCRIPTION
## Summary

Fix argument injection / RCE in the npm command handler by replacing `escapeshellcmd` with `escapeshellarg` and adding a command whitelist.

## Problem

The `node_npm()` function uses `escapeshellcmd()` which is **the wrong escaping function** for this use case:

```php
function node_npm($cmd) {
    $cmd = escapeshellcmd(NODE_DIR . "/bin/npm --cache ./.npm -- $cmd");
    passthru($cmd, $ret);
}
```

`escapeshellcmd()` escapes shell metacharacters like `;`, `|`, `&` but does **NOT prevent argument injection**. Since `$cmd` comes from `$_GET['npm']`, an attacker can:

1. **Install malicious packages**: `?npm=install evil-package` — installs arbitrary npm packages that can execute post-install scripts
2. **Execute arbitrary commands via npm exec**: `?npm=exec -- /bin/sh` (npm 7+)
3. **Exfiltrate data**: `?npm=pack --pack-destination=/tmp` combined with other attacks

### escapeshellcmd vs escapeshellarg

- `escapeshellcmd()`: Escapes shell metacharacters in a **complete command** — prevents command chaining but NOT argument injection
- `escapeshellarg()`: Wraps a **single argument** in quotes — prevents both command chaining AND argument injection

## Fix

1. **Whitelist** allowed npm subcommands (`install`, `uninstall`, `update`, `list`, etc.)
2. Replace `escapeshellcmd` with `escapeshellarg` for the user-supplied argument

## Impact

- **Type**: Remote Code Execution via Argument Injection (CWE-88)
- **Affected function**: `node_npm()` via `?npm=` parameter
- **Risk**: Arbitrary code execution via malicious npm packages or npm exec
- **OWASP**: A03:2021 — Injection